### PR TITLE
[Feat] con.configUsername() 메서드 구현

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 import { initializeApp } from 'firebase/app';
+import { getFirestore, collection, addDoc } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,4 +14,14 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 
-export default app;
+const store = getFirestore(app);
+
+const addDataToCollection = async (collectionName, data) => {
+  try {
+    await addDoc(collection(store, collectionName), data);
+  } catch (error) {
+    console.error('Error adding document: ', error);
+  }
+};
+
+export { app, addDataToCollection, store };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "con.chat",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -1,11 +1,14 @@
 import { getDatabase, ref, set, onValue } from 'firebase/database';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import { addDataToCollection, store } from '../main.js';
+import DEFAULT_USER_NAME from './constant/chat.js';
 
 class Con {
   #state = false;
   #language = null;
-  #username = '아무개';
-
   #database = getDatabase();
+  #username = DEFAULT_USER_NAME;
+  #hasUsername = false;
 
   #isStarted() {
     return this.#state === false;
@@ -40,6 +43,13 @@ class Con {
     });
   }
 
+  #addUserToStore(username) {
+    this.#hasUsername = true;
+    this.#username = username;
+
+    addDataToCollection('users', { username });
+  }
+
   chat() {
     this.#state = true;
     console.log(
@@ -53,6 +63,7 @@ class Con {
   setLanguage(language) {
     if (this.#isStarted()) {
       console.log('🚫 con.chat()을 실행해주세요.');
+
       return;
     }
 
@@ -62,6 +73,7 @@ class Con {
       console.log(
         `💁🏻 유효하지 않은 언어입니다.\n'js' 또는 'react'를 입력해주세요.`,
       );
+
       return;
     }
 
@@ -80,6 +92,37 @@ class Con {
     }
 
     this.#sendMessage('messages', message);
+  }
+
+  configUsername(username) {
+    if (this.#isStarted()) {
+      console.log('🚫 con.chat()을 실행해주세요.');
+
+      return;
+    }
+
+    if (this.#hasUsername) {
+      console.log(`💁🏻 ${this.#username}님, 이미 이름을 설정하셨네요!`);
+
+      return;
+    }
+
+    (async () => {
+      const usersQuery = query(
+        collection(store, 'users'),
+        where('username', '==', username),
+      );
+      const userQuerySnapshot = await getDocs(usersQuery);
+      const isUsernameExists = !userQuerySnapshot.empty;
+
+      if (isUsernameExists) {
+        console.log('🚫 이미 존재하는 이름입니다. 다시 설정해 주세요.');
+      } else {
+        this.#addUserToStore(username);
+
+        console.log(`💁🏻 ${username}님 안녕하세요!`);
+      }
+    })();
   }
 }
 

--- a/src/constant/chat.js
+++ b/src/constant/chat.js
@@ -1,0 +1,3 @@
+const DEFAULT_USER_NAME = '아무개';
+
+export default DEFAULT_USER_NAME;


### PR DESCRIPTION
## 테스크 제목

[[T-06] con.configUsername() 구현 - 사용자 이름 설정](https://www.notion.so/eunmi/T-06-con-configUsername-03e039d8a80d4123b033306d43c7b1db?pvs=4)

<br>

## 설명

- 사용자 이름 설정 기능 및 중복 설정 유효성 검증 추가
- Firestore 보일러 플레이트 추가
- Firestore 데이터 저장 util 함수 추가
- 채팅에서 사용되는 상수 관리위해 constant/chat.js 추가 및 상수 선언

<br>

## 주안점
프라이빗 필드에 사용자 이름 중복 검증 로직 은닉화 시도했으나 아래의 문제로 분리가 어려움
- 중복 검증을 먼저 작성하면 결과값을 반환하는 것이 불가피 
- 결과값은 Promise 객체로 오기 때문에 콘솔에 Promise객체가 보이는 문제 
- 결과적으로, 중복 검증하는 로직을 confirUsername 메서드 내부에 작성

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.