### PR TITLE
[Refactor] 실시간 채팅 시 username 미반영 문제 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "1.0.0",
+      "version": "0.4.1",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -18,15 +18,9 @@ class Con {
     return this.#language !== 'js' && this.#language !== 'react';
   }
 
-  #hasValidStateAndLanguage() {
-    return (
-      (this.#language !== 'js' && this.#language !== 'react') ||
-      this.#state !== true
-    );
-  }
-
   #sendMessage(collectionName, messageContent) {
     set(ref(this.#database, `chats/${collectionName}`), {
+      username: this.#username,
       messageContent,
     });
   }
@@ -37,9 +31,9 @@ class Con {
     onValue(databaseRef, (snapshot) => {
       const messages = snapshot.val();
 
-      if (messages === null) return;
+      if (!messages || !messages.messageContent || !messages.username) return;
 
-      console.log(`<${this.#username}>: ${messages.messageContent}`);
+      console.log(`<${messages.username}>: ${messages.messageContent}`);
     });
   }
 


### PR DESCRIPTION
## 테스크 제목
[[T-10] 1차 리팩토링
](https://www.notion.so/eunmi/T-10-1b1620acf378467fbb3b2b5386df722a)
<br>

## 설명
- con.speak() 메서드, con.configUsername() 메서드 구현 후 채팅 기능에서 username이 반영되지 않는 문제 해결
- 불필요 함수 삭제

<br>

## 주안점
- 기존 로직에서는 데이터를 읽는 로직에서 username 데이터로서 프라이빗 변수(#username)를 사용했는데, 실시간 반영이 필요한 것으로 판단하여 메시지를 보내는 함수(#sendMessage())에서 사용자가 설정한 #username을 메시지와 함께 전송하여 메시지를 읽는 함수(#ListenForMessages())에서 username을 읽을 수 있도록 수정

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.