### PR TITLE
[Feat] con.createDebugRoom() 메서드 구현

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,12 @@
 import { initializeApp } from 'firebase/app';
-import { getFirestore, collection, addDoc } from 'firebase/firestore';
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  doc,
+  updateDoc,
+  arrayUnion,
+} from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -18,10 +25,26 @@ const store = getFirestore(app);
 
 const addDataToCollection = async (collectionName, data) => {
   try {
-    await addDoc(collection(store, collectionName), data);
+    const docRef = await addDoc(collection(store, collectionName), data);
+
+    return docRef.id;
   } catch (error) {
     console.error('Error adding document: ', error);
+
+    throw error;
   }
 };
 
-export { app, addDataToCollection, store };
+const addUserToRoom = async (roomId, username) => {
+  try {
+    const roomRef = doc(store, 'debugRooms', roomId);
+
+    await updateDoc(roomRef, {
+      users: arrayUnion(username),
+    });
+  } catch (error) {
+    console.error('Error adding user to room: ', error);
+  }
+};
+
+export { app, addDataToCollection, addUserToRoom, store };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -33,7 +33,7 @@ class Con {
   }
 
   #listenForMessages(roomId) {
-    if (this.#messageListener) {
+    if (typeof this.#messageListener === 'function') {
       off(
         ref(this.#database, `chats/${this.#currentRoom}`),
         this.#messageListener,


### PR DESCRIPTION
## 테스크 제목

[[T-07] con.createDebugRoom() 구현 - 대화방 생성
](https://www.notion.so/eunmi/T-07-con-createDebugRoom-eb42f3cd8ef64343a11808a71d9342d3)

<br>

## 설명

- 방 생성 기능 및 중복 설정 유효성 검증 추가
- Firestore 데이터 저장 util 함수 문서 ID 추출을 위해 수정
- 해당 방에 속한 사용자 추가하기 위한 util 함수 추가
- 현재 사용자가 속한 방을 추적하는 로직 추가
- 메시지 전송 및 수신 로직도 사용자가 속한 방에만 가능하도록 로직 수정

<br>

## 주안점

- 방이 바뀔 때마다 해당 방을 참조하고 있는 리스너가 바뀌기 때문에 기존 리스너 제거 후 새로운 리스너 설정하여 메시지 중복 수신을 방지
- Firestore의 배열 필드를 사용하여 디버깅 방 데이터 단순화
- this.#currentRoom 변수를 통해 현재 사용자가 속한 방을 정확하게 추적

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.