### PR TITLE
[Feat] con.listRooms 메서드 구현

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import {
   getFirestore,
   collection,
   addDoc,
+  getDocs,
   doc,
   updateDoc,
   arrayUnion,
@@ -47,4 +48,17 @@ const addUserToRoom = async (roomId, username) => {
   }
 };
 
-export { app, addDataToCollection, addUserToRoom, store };
+const getRoomNames = async () => {
+  try {
+    const roomsQuery = collection(store, 'debugRooms');
+    const roomsSnapshot = await getDocs(roomsQuery);
+
+    return roomsSnapshot.docs.map((document) => document.data().roomName);
+  } catch (error) {
+    console.error('Error fetching rooms:', error);
+
+    throw error;
+  }
+};
+
+export { app, addDataToCollection, addUserToRoom, getRoomNames, store };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -1,7 +1,12 @@
 import { getDatabase, ref, set, onValue, remove, off } from 'firebase/database';
 import { collection, query, where, getDocs } from 'firebase/firestore';
 
-import { addDataToCollection, addUserToRoom, store } from '../main.js';
+import {
+  addDataToCollection,
+  addUserToRoom,
+  getRoomNames,
+  store,
+} from '../main.js';
 
 import { DEFAULT_USER_NAME, CODE_BLOCK_STYLE } from './constant/chat.js';
 import { getXPath, getElementByXPath } from './utils/element.js';
@@ -234,6 +239,32 @@ class Con {
         }
       } catch (error) {
         console.error('Error creating room:', error);
+      }
+    })();
+  }
+
+  listRooms() {
+    if (this.#isStarted()) {
+      console.log('🚫 con.chat()을 실행해주세요.');
+
+      return;
+    }
+
+    (async () => {
+      try {
+        const rooms = await getRoomNames();
+
+        if (rooms.length === 0) {
+          console.log('🚫 디버깅 방이 없습니다.');
+        } else {
+          console.log('💁🏻 디버깅 방 리스트 입니다. \n\n👇');
+
+          rooms.forEach((room) => {
+            console.log(room);
+          });
+        }
+      } catch (error) {
+        console.error('Error fetching rooms:', error);
       }
     })();
   }


### PR DESCRIPTION
## 테스크 제목

[[T-13] con.listRooms() 구현 - 대화방 리스트 조회
](https://www.notion.so/eunmi/T-13-con-listRooms-406161df6e664ea8b0a2f974efb93cb1)
<br>

## 설명
con.listRooms(): 모든 대화방의 목록을 조회하는 기능

- listRooms 메서드
    - public을 제외한 모든 방 이름을 표시
    - 방의 유무에 대해 다른 메세지 출력
- getRoomNames 함수
    - Firestore의 debugRooms 컬렉션에서 방 이름을 가져오는 로직
<br>

## 주안점

- getRoomNames 유틸리티 함수를 main.js에 별도로 정의하여, Firestore에서 방 이름을 가져오는 로직을 재사용
- 방 목록의 유무에 따라 다른 메세지를 출력하기 때문에 현재 사용 가능한 방 목록을 쉽게 파악 가능

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.