### PR TITLE
[Fix] RealTime 데이터 구조 설계 및 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -7,7 +7,7 @@ import {
   off,
   push,
 } from 'firebase/database';
-import { collection, query, where, getDocs } from 'firebase/firestore';
+import { collection, query, where, getDocs, addDoc } from 'firebase/firestore';
 
 import {
   addDataToCollection,
@@ -26,6 +26,7 @@ class Con {
   #language = null;
   #database = getDatabase();
   #username = DEFAULT_USER_NAME;
+  #userId = null;
   #hasUsername = false;
   #initialDomTree = null;
   #messageListener = null;
@@ -141,11 +142,14 @@ class Con {
     this.#currentRoom = roomId;
   }
 
-  #addUserToStore(username) {
-    this.#hasUsername = true;
+  async #addUserToStore(username) {
     this.#username = username;
 
-    addDataToCollection('users', { username });
+    const userDocRef = await addDoc(collection(store, 'users'), {
+      username: this.#username,
+    });
+
+    this.#userId = userDocRef.id;
   }
 
   set initialDomTree(domTree) {
@@ -184,6 +188,7 @@ class Con {
 
     this.#clearDatabase();
     this.#listenForMessages(this.#currentRoom);
+    this.#addUserToStore(this.#username);
   }
 
   setLanguage(language) {


### PR DESCRIPTION
## 테스크 제목
[[T-12] RealTime 데이터 구조 설계 및 리팩토링
](https://debonair-bread-c72.notion.site/T-12-RealTime-529c408c29444b9e94bc6e810dc0b7c9)
<br>

## 설명

- Realtime Database 구조 재설계
- 타임스탬프와 키를 활용하여 중복 메시지 추출 해결
- 사용자 아이디 생성 및 저장 기능으로 addUserToStore 메서드 변경
- con.configUsername() 메서드 내 중복 검사 로직 분리


<br>

## 주안점

- `sendMessage` 메서드 : Realtime Database 구조 재설계
https://github.com/Team-macoss/con.chat/blob/7e6b3f5e1f47b36a1560f256a7299e552f35e91f/src/conchat.js#L66-L80
기존에는 push대신 set 메서드를 사용하여 메시지를 저장했습니다. 
set 메서드는 지정된 경로에 데이터를 설정하므로, 고유한 키 없이 데이터를 저장하게 된다면 메시지의 순서도 보장되지 않고, 중복 메시지 처리가 어려웠습니다. 
새로운 구조에서는 이러한 문제를 방지하기 위해 각 메시지에 고유한 키를 부여하여 메시지를 저장하게 되었습니다.
또 메서드마다 `listenForMessages`과 `listenForStyleChanges`등 별도의 리스닝 메서드가 늘어나게 되면 유지보수가 어려울 것이라 생각하여 재사용성을 높이기 위해 type 필드를 추가하여 다양한 메시지를 하나의 메서드 `listenForMessages`로 함수 내에 분기 처리해주었습니다.

- `listenForMessages` 메서드 : 타임스탬프와 키를 활용하여 중복 메시지 추출 해결
https://github.com/Team-macoss/con.chat/blob/7e6b3f5e1f47b36a1560f256a7299e552f35e91f/src/conchat.js#L91-L130
기존에는 단순히 `snapshot.val()`을 사용하여 메시지를 가져오기 때문에 중복 메시지를 걸러내지 못했습니다. 그렇기 때문에 각 메시지에 타임스탬프과 메시지 키를 추가하여, 마지막으로 처리된 메시지 이후의 새로운 메시지만 출력되도록 하였습니다.
메시지 순서도 보장하기 위하여 타임스탬프를 먼저 비교한 후 타임스탬프가 같은 경우 메시지 키를 비교하였습니다. Firebase의 메시지 키는 시간순으로 증가하도록 설계되어있기 때문에 더 최근의 메시지를 판단할 수 있었습니다.

- `addUserToStore` 메서드 : 사용자 아이디 생성 및 저장 기능
https://github.com/Team-macoss/con.chat/blob/7e6b3f5e1f47b36a1560f256a7299e552f35e91f/src/conchat.js#L150-L158
기존에는 `con.chat()`을 실행한 후 별도로 `con.configUsername()`을 호출해야 사용자 이름이 호출되고 데이터베이스에 저장되었습니다. 이로 인해 `con.configUsername()`을 호출하지 않으면 사용자 이름이 설정되지 않아, 해당 사용자를 정확히 구분할 수 없었습니다.
사용자 구분 문제를 해결하기 위해 `con.chat()` 실행 시 고유한 아이디를 부여하여 각 사용자를 정확히 구분할 수 있게 되었습니다.

- `con.configUsername()` 메서드 비동기 로직(`validateUsername()`) 분리
https://github.com/Team-macoss/con.chat/blob/7e6b3f5e1f47b36a1560f256a7299e552f35e91f/src/conchat.js#L262-L274
기존에는 메서드 내부에 즉시 실행 함수로 사용자 이름의 중복을 검사하는 비동기 로직이 작성되어 있었으나,
가독성 및 캡슐화를 위해 프라이빗 메서드로 분리하였습니다.
비동기 함수인 `validateUsername()`을 호출하여 결과값을 얻기 위해서는 이를 호출하는 함수에서 `async` 키워드가 사용되어야 합니다.
하지만 `con.confitUsername()` 메서드는 console 창에서 사용자들이 직접 사용하는 static 메서드로  `async` 함수로 작성될 경우
`Promise` 객체를 반환하게 되어 console 창에 `Promise` 객체가 보이는 문제가 있습니다.
따라서 `Promise.prototype.then()`을 이용하여 로직을 처리해주었습니다.
<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.