### PR TITLE
[Feat] con.enterDebugRoom() 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -170,20 +170,10 @@ class Con {
   }
 
   async #isRoomValid(roomName, roomKey) {
-    const roomsRef = this.#getRef('chats/rooms');
-    const snapshot = await get(roomsRef);
+    const roomRef = this.#getRef(`chats/rooms/${roomKey}`);
+    const snapshot = await get(roomRef);
 
-    let isValidKey = false;
-
-    snapshot.forEach((childSnapshot) => {
-      const roomData = childSnapshot.val();
-
-      if (roomData.name === roomName && childSnapshot.key === roomKey) {
-        isValidKey = true;
-      }
-    });
-
-    return isValidKey;
+    return snapshot.exists() && snapshot.val().name === roomName;
   }
 
   async #checkForDuplicates(path, field, value) {


### PR DESCRIPTION

## 테스크 제목
[[T-15] con.enterDebugRoom() 구현 - 대화방 입장](https://www.notion.so/T-15-con-enterDebugRoom-41a1b1ed606649d0aedee7736e04e55a?pvs=4)

<br>

## 설명

con.enterDebugRoom('rooName', 'roomKey'): 
존재하는 방이름과 방의 고유키값을 인자로 전달하면 유효성 검증 후 방에 입장할 수 있도록 하는 기능 구현, 방 입장시 모든 DOM조작 메서드 사용 가능

1. **con.enterDebugRoom() 메서드 정의**
2. **con.enterDebugRoom()에서 필요한 DB 업데이트 로직 추가**
    
    ```
    <DB>
    users
    	- userID
    		- roomName (현재 위치한 roomname 업데이트)
    		
    rooms
    	- roomID
    		- userList: [user1, user2 ...]
    		: 입장할 방 이외의 방의 userList에서 userName 삭제
    		: 입장할 방의 userList에 userName 업데이트
    		
    
    <METHOD>
    sendMessage
    	- roomID: 입장할 방의 roomID
    	- messageType: 'enterRoom'
    	- messageContennt: null
    ```
    
3. **createDebugRoom, enterDebugRoom 메서드에 roomName, roomKey 유효성 검증 로직 추가 (type 체크)**

<br>

## 주안점
- **`roomName`과 `roomKey` 일치 여부 유효성 로직**
https://github.com/Team-macoss/con.chat/blob/ec8d05c3ea6823305f99d80105547d6a4d838d89/src/conchat.js#L172-L187
사용자가 입력한 방이름과 `key`값이 일치하는지 여부를 판별하는 로직입니다. 
프라이빗 메서드로 작성하였으며 `con.enterDebugRoom()` 메서드 내에서 호출됩니다.
반환 값은 일치 여부이며 이에 따라 출력되는 console 내용이 달라집니다.

- **순차적인 유효성 검증을 위한 프로미스 체이닝**
https://github.com/Team-macoss/con.chat/blob/ec8d05c3ea6823305f99d80105547d6a4d838d89/src/conchat.js#L440-L474
사용자가 방에 입장하기 위해서는 
1. 존재하는 방인지 확인
2. 존재하는 방이라면 방이름과 입력한 key값이 같은지 확인
<br>
순차적으로 유효성을 검증해야 사용자에게 알맞은 안내메시지를 출력할 수 있습니다.
사용자 메서드(console창에서 사용자들이 이용하게 될 메서드)는 async/await을 사용하지 못하므로, 프로미스 체이닝을 이용하여 순차적으로 검증하도록 구현하였습니다. <br>
첫 번째 검증 로직인 방이름 중복 검사를 통과하지 못할 경우, 바로 프로미스 체이닝을 탈출하여야 이후 검증 로직이 진행되지 않으므로 바로 Error를 던져 체이닝을 해제해주었습니다. <br>
(그렇지 않으면, 방이름 중복 로직을 통과하지 못함에도 key를 검사하는 로직으로 넘어가 안내메시지 콘솔이 모두 출력되는 결과가 발생합니다.)

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.