### PR TITLE
[Feat] con.insertElement() 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/constant/chat.js
+++ b/src/constant/chat.js
@@ -3,4 +3,7 @@ const DEFAULT_USER_NAME = '아무개';
 const CODE_BLOCK_STYLE =
   'padding: 3px; border-radius: 3px; background-color: #ededeb; color: #37352f;';
 
-export { DEFAULT_USER_NAME, CODE_BLOCK_STYLE };
+const TEXT_BLOCK_STYLE =
+  'padding: 3px; border-radius: 3px; background-color: #fbfb87; color: #37352f;';
+
+export { DEFAULT_USER_NAME, CODE_BLOCK_STYLE, TEXT_BLOCK_STYLE };

--- a/src/utils/element.js
+++ b/src/utils/element.js
@@ -6,18 +6,18 @@ const getXPath = (element) => {
     return '/html/body';
   }
 
-  let ix = 0;
+  let index = 0;
   const siblings = element.parentNode.childNodes;
 
   for (let i = 0; i < siblings.length; i++) {
     const sibling = siblings[i];
 
     if (sibling === element) {
-      return `${getXPath(element.parentNode)}/${element.tagName}[${ix + 1}]`;
+      return `${getXPath(element.parentNode)}/${element.tagName}[${index + 1}]`;
     }
 
     if (sibling.nodeType === 1 && sibling.tagName === element.tagName) {
-      ix++;
+      index++;
     }
   }
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -5,4 +5,10 @@ const isValidCSS = (styleCode) => {
   return dummyElement.style.length > 0;
 };
 
-export default isValidCSS;
+const isValidPosition = (position) => {
+  const positions = ['beforebegin', 'afterbegin', 'beforeend', 'afterend'];
+
+  return positions.includes(position.toLowerCase());
+};
+
+export { isValidCSS, isValidPosition };


### PR DESCRIPTION
## 테스크 제목
[[T-16] con.insertElement() 구현 - 클릭한 요소의 주변에 이미 생성된 DOM 요소 이동
](https://www.notion.so/T-16-con-insertElement-DOM-4b413e16440b43238bec7c67543ce9c3?pvs=4)<br>

## 설명
`con.insertElement(element, 'position')`
사용자가 개발자 도구에서 클릭한 요소 주변에 이미 생성된 요소를 삽입 가능, 해당 방에 입장한 모든 수신자들의 DOM에도 동일하게 적용
이미 생성된 요소인 element는 insertElement 실행 전 javascript 문법으로 접근 가능

1. `con.insertElement()` 메서드 정의
2. 사용자 입력 위치값이 유효한지 판단을 위한 `isValidPosition` 함수 추가
3. 공통된 검증 로직을 `checkDomPreconditions` 메서드로 한 곳에 관리

<br>

## 주안점

- **insertElement 메서드 입력 유효성 검증**
  https://github.com/Team-macoss/con.chat/blob/f1ed569eee7186404aaa07eb737baddb59ed8579/src/conchat.js#L623-L628
   https://github.com/Team-macoss/con.chat/blob/f1ed569eee7186404aaa07eb737baddb59ed8579/src/utils/validation.js#L8-L12
  사용자로부터 입력받은 `position` 매개변수를 소문자로 통일함으로써 대소문자와 관계없이 일관된 조건 검사를 수행할 수 있도록 했습니다. 
  `isValidPosition` 함수를 통해 `position` 값이 유효한지 검사하여, 잘못된 값이 입력된다면 오류 메시지를 제공하고 실행을 중단합니다.
  
- **DOM 관련 메서드 공통된 검증 로직 통합 및 개선**
  https://github.com/Team-macoss/con.chat/blob/f1ed569eee7186404aaa07eb737baddb59ed8579/src/conchat.js#L315-L354
  기존에는 각 DOM 조작 메서드마다 개별적으로 수행되던 사전 검증 로직이 중복되어 코드의 길이가 불필요하게 길어져, 같은 로직의 반복 수정이 필요한 문제가 있었습니다. 이를 해결하기 위해 모든 DOM 조작 메서드에서 공통적으로 요구되는 사전 조건을 `checkDomPreconditions` 메서드 하나로 통합하여, 필요한 검증을 한 곳에서 처리하도록 개선하였습니다.

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.