### PR TITLE
[Feat] con.changeText() 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -123,7 +123,7 @@ class Con {
         newMessages.forEach((message) => {
           if (message.type === 'text') {
             console.log(`<${message.username}>: ${message.content.text}`);
-          } else if (message.type === 'style') {
+          } else if (message.type === 'changeStyle') {
             const { xpath, style } = message.content;
 
             this.#applyStyleByXPath(xpath, style, message.username);
@@ -133,7 +133,7 @@ class Con {
             if (this.#username !== username) {
               console.log(`${username}님이 입장했습니다.`);
             }
-          } else if (message.type === 'insert') {
+          } else if (message.type === 'insertElement') {
             const { targetXPath, elementXPath, position } = message.content;
 
             this.#applyInsertByXPath(
@@ -142,6 +142,10 @@ class Con {
               position,
               message.username,
             );
+          } else if (message.type === 'changeText') {
+            const { xpath, text } = message.content;
+
+            this.#applyTextByXPath(xpath, text, message.username);
           }
         });
 
@@ -290,6 +294,22 @@ class Con {
 
     if (element) {
       element.style.cssText += styleCode;
+    }
+  }
+
+  #applyTextByXPath(xpath, text, username) {
+    const element = getElementByXPath(xpath);
+
+    if (username !== this.#username) {
+      console.log(
+        `💁🏻 ${username}님이 텍스트를 변경했습니다. \n\n👇 %ccon.changeText('${text}')`,
+        CODE_BLOCK_STYLE,
+      );
+      console.log(element);
+    }
+
+    if (element) {
+      element.textContent = text;
     }
   }
 
@@ -609,10 +629,35 @@ class Con {
     this.#sendMessageAsync(
       this.#currentRoomKey,
       { xpath, style: styleCode },
-      'style',
+      'changeStyle',
     );
 
     console.log('💁🏻 스타일이 사용자들의 화면에 적용되었습니다.');
+  }
+
+  changeText(text) {
+    const targetElement = this.#checkDomPreconditions();
+
+    if (!targetElement) return;
+
+    if (typeof text !== 'string') {
+      console.log('🚫 텍스트는 문자열로 입력해주세요.');
+
+      return;
+    }
+
+    const xpath = getXPath(targetElement);
+    const element = getElementByXPath(xpath);
+
+    if (!element) {
+      console.log('🚫 유효하지 않은 요소입니다. 다른 요소를 선택해주세요.');
+
+      return;
+    }
+
+    this.#sendMessageAsync(this.#currentRoomKey, { xpath, text }, 'changeText');
+
+    console.log('💁🏻 변경된 텍스트가 사용자들의 화면에 적용되었습니다.');
   }
 
   insertElement(element, position) {
@@ -652,7 +697,7 @@ class Con {
         elementXPath,
         position,
       },
-      'insert',
+      'insertElement',
     );
 
     console.log('💁🏻 변경된 요소가 사용자들의 화면에 적용되었습니다.');


### PR DESCRIPTION
## 테스크 제목
[[T-17] con.changeText() 구현 - 클릭한 요소의 텍스트 변경
](https://www.notion.so/T-17-con-changeText-cb22e8befc974391a201baf7d11a4a7f?pvs=4)
<br>

## 설명
`con.changeText('text')`
사용자가 개발자 도구에서 클릭한 요소의 텍스트 변경하는 기능 구현

1. `con.changeText()` 메서드 정의
2. 서버로부터 받은 변경 요청을 통해 실제 DOM 요소의 텍스트를 업데이트하기 위한 `#applyTextByXPath` 메서드를 구현

<br>

## 주안점

- `innerText` 대신 [`textContent`](https://developer.mozilla.org/ko/docs/Web/API/Node/textContent) 사용
  https://github.com/Team-macoss/con.chat/blob/2766a306629bdfb0f46a209d35eee8a1de40c259/src/conchat.js#L311-L313
  `innerText` 같은 경우 css 스타일을 계산하여 텍스트를 렌더링하기 때문에 `changeStyle` 메서드로 인라인 스타일을 변경한 이후 `changeText` 메서드를 실행하게 된다면 `innerText`가 스타일 변경을 반영하여 예상하지 못한 텍스트를 반환할 수 있습니다. 
그리고 css 스타일을 고려하여 계산을 수행한 후 텍스트를 처리하기 때문에 순수하게 텍스트만 추출하는 `textContent`보다 성능이 느릴 수 밖에 없습니다. 
그 외에 XSS 공격에도 취약할 수 있다는 점이 있어 입력된 텍스트가 그대로 텍스트 노드에 반영되어 해당 공격을 방지하는데 효과적인 `textContent`를 사용하게 되었습니다.

- `changeText` 메서드 사전 조건 및 텍스트 유효성 검증
  https://github.com/Team-macoss/con.chat/blob/2766a306629bdfb0f46a209d35eee8a1de40c259/src/conchat.js#L638-L647
  `#checkDomPreconditions` 메서드를 호출하여 DOM 조작에 필요한 사전 조건을 검증하고 입력받은 `text`가 문자열인지 확인하여, 그렇지 않은 경우 오류 메시지를 출력하고 실행을 중단합니다.

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.