### PR TITLE
[Feat] con.leaveDebugRoom() 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/constant/chat.js
+++ b/src/constant/chat.js
@@ -1,3 +1,4 @@
+const PUBLIC_ROOM_KEY = 'public';
 const DEFAULT_USER_NAME = '아무개';
 
 const CODE_BLOCK_STYLE =
@@ -6,4 +7,9 @@ const CODE_BLOCK_STYLE =
 const TEXT_BLOCK_STYLE =
   'padding: 3px; border-radius: 3px; background-color: #fbfb87; color: #37352f;';
 
-export { DEFAULT_USER_NAME, CODE_BLOCK_STYLE, TEXT_BLOCK_STYLE };
+export {
+  PUBLIC_ROOM_KEY,
+  DEFAULT_USER_NAME,
+  CODE_BLOCK_STYLE,
+  TEXT_BLOCK_STYLE,
+};


### PR DESCRIPTION

## 테스크 제목
[[T-18] con.leaveDebugRoom() 구현 - 대화방 나가기](https://www.notion.so/T-18-con-leaveDebugRoom-fe92133e0fcf44e9a1c145919bbff40b?pvs=4)

<br>

## 설명
`con.leaveDebugRoom()`:
방에 입장해있는 경우 leaveDebugRoom() 메서드를 이용하여 전체 채널로 이동하는 기능 
퇴장 시 사용자 콘솔 창에 퇴장 안내 메시지 출력
방을 이용중인 다른 사용자들의 콘솔 창에 `OO님이 퇴장했습니다.` 안내 메시지 출력

1. **con.leaveDebugRoom() 메서드 정의**

2. **방 만들기, 입장, 나가기 메서드 내 유효성 검증 로직 최적화**

3. **방 관련 DB 데이터 변경**
  
   추후 기능 확장성을 위해 고유 값(key)을 저장하는 방향으로 수정
  ```
<DB>
users
	- userID
		- roomKey (현재 위치한 roomKey 업데이트)
                 : As-Is roomname 저장
                 : To-Be roomKey 저장
		
rooms
	- roomID
		- userList: [user1Key, user2Key ...]
                 : As-Is username 저장
                 : To-Be userKey 저장

```

<br>

## 주안점

- 전체 채널(public)용 roomKey 상수화
 https://github.com/Team-macoss/con.chat/blob/2b786bdc5da5591ad064f7952e78539ed1c819db/src/constant/chat.js#L1
 매직 리터럴로 사용되던 `'public'` 문자열을 상수화하였습니다. 
 
- 유효성 검증 관련 비동기 로직 최적화
  https://github.com/Team-macoss/con.chat/blob/2b786bdc5da5591ad064f7952e78539ed1c819db/src/conchat.js#L636-L660

방을 퇴장하는 기능은 퇴장하는 사용자에게 안내 메시지가 출력됨과 함께 방을 이용 중이던 다른 사용자들에게도 다른 사용자가 퇴장했다는 안내메시지 출력이 필요합니다. 
즉, 발신자는 방을 퇴장함과 동시에 전체 채널에 대한 리스너로 재등록 해야하며,
방을 퇴장했다는 사실을 알리는 메시지를 서버 측에 전송해야합니다. 
이 과정은 동기적으로 이루어져야 합니다.
반면, 사용자의 퇴장에 따라 이루어지는 DB 정보의 업데이트는 정보 간의 연결성이 없다면,
병렬적으로 처리되는 것이 성능상 유리합니다. 

따라서 `con.leaveDebugRoom()` 로직 내부에서 `Promise 체이닝`을 이용하여 순차적으로 이루어져야 할 비동기 로직을 처리해주었으며, 마지막 단계에서 `Promise.all`을 이용하여 순서가 중요하지 않은 로직들을 동시에 처리해주었습니다. 
이는 모든 room 관련 메서드(`con.createDebugRoom()`, `con.enterDebugRoom()`)에서 비슷한 과정으로 처리될 수 있도록 리팩토링하였습니다.
<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.