### PR TITLE
[Feat] con.showComponentTree() 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -21,7 +21,11 @@ import {
   TEXT_BLOCK_STYLE,
 } from './constant/chat.js';
 import { getXPath, getElementByXPath } from './utils/element.js';
-import { traverseFragment, findReactRootContainer } from './utils/component.js';
+import {
+  traverseFragment,
+  findReactRootContainer,
+  drawComponentTree,
+} from './utils/component.js';
 import { isValidCSS, isValidPosition } from './utils/validation.js';
 
 class Con {
@@ -882,6 +886,30 @@ class Con {
         console.log(component);
       }
     });
+  }
+
+  showComponentTree() {
+    if (this.#isStarted()) {
+      console.log('🚫 con.chat()을 실행해주세요.');
+
+      return;
+    }
+
+    if (this.#language !== 'react') {
+      console.log(
+        `🚫 현재 선택된 언어는 ‘react’가 아닙니다. con.setLanguage('react')를 실행해주세요.`,
+      );
+
+      return;
+    }
+
+    if (this.#currentRoomKey === 'public') {
+      console.log('🚫 debug방이 아닌 곳에서 실행할 수 없습니다.');
+
+      return;
+    }
+
+    drawComponentTree();
   }
 }
 

--- a/src/constant/chat.js
+++ b/src/constant/chat.js
@@ -1,15 +1,39 @@
 const PUBLIC_ROOM_KEY = 'public';
 const DEFAULT_USER_NAME = '아무개';
 
-const CODE_BLOCK_STYLE =
-  'padding: 3px; border-radius: 3px; background-color: #ededeb; color: #37352f;';
+const CODE_BLOCK_STYLE = `
+  padding: 3px;
+  border-radius: 3px;
+  background-color: #ededeb;
+  color: #37352f;
+`;
 
-const TEXT_BLOCK_STYLE =
-  'padding: 3px; border-radius: 3px; background-color: #fbfb87; color: #37352f;';
+const TEXT_BLOCK_STYLE = `
+  padding: 3px;
+  border-radius: 3px;
+  background-color: #fbfb87;
+  color: #37352f;
+`;
+
+const COMPONENT_BLOCK_STYLE = `
+  background-color: #F2CF65;
+  color: #000;
+  padding: 3px 5px;
+  border - radius: 4px;
+`;
+
+const ROOT_COMPONENT_BLOCK_STYLE = `
+  background-color: #96D259;
+  color: #000;
+  padding: 3px 5px;
+  border-radius: 4px;
+`;
 
 export {
   PUBLIC_ROOM_KEY,
   DEFAULT_USER_NAME,
   CODE_BLOCK_STYLE,
   TEXT_BLOCK_STYLE,
+  COMPONENT_BLOCK_STYLE,
+  ROOT_COMPONENT_BLOCK_STYLE,
 };

--- a/src/utils/component.js
+++ b/src/utils/component.js
@@ -1,3 +1,8 @@
+import {
+  COMPONENT_BLOCK_STYLE,
+  ROOT_COMPONENT_BLOCK_STYLE,
+} from '../constant/chat.js';
+
 const findReactRootContainer = () => {
   const bodyElements = document.body.children;
 
@@ -39,4 +44,173 @@ const traverseFragment = (component) => {
   return fragmentComponents;
 };
 
-export { traverseFragment, findReactRootContainer };
+const colorize = (text, styles) => {
+  return [`%c${text}`, styles];
+};
+
+const findReactRootNode = (element) => {
+  if (!element) return null;
+
+  if (
+    Object.keys(element).some(
+      (key) =>
+        key.startsWith('__reactFiber$') ||
+        key.startsWith('__reactInternalInstance$'),
+    )
+  ) {
+    return element;
+  }
+
+  const childrenArray = Array.from(element.children);
+  let reactNode = null;
+
+  childrenArray.some((children) => {
+    reactNode = findReactRootNode(children);
+
+    return reactNode;
+  });
+
+  return reactNode;
+};
+
+const findReactFiber = (element) => {
+  const reactKey = Object.keys(element).find(
+    (key) =>
+      key.startsWith('__reactFiber$') ||
+      key.startsWith('__reactInternalInstance$'),
+  );
+
+  return reactKey ? element[reactKey] : null;
+};
+
+const findHostComponent = (fiber) => {
+  let node = fiber;
+
+  while (node) {
+    if (node.stateNode instanceof HTMLElement) {
+      return node.stateNode;
+    }
+
+    node = node.child;
+  }
+
+  return null;
+};
+
+const traverseFiberTree = (
+  fiber,
+  depth = 0,
+  isLast = true,
+  prefix = '',
+  isRoot = false,
+) => {
+  if (!fiber) return;
+
+  const connector = isLast ? '└─' : '├─';
+  const line = depth > 0 ? `${prefix}${connector}` : '';
+
+  if (isRoot) {
+    const domElement = findHostComponent(fiber);
+    const componentType = '▸';
+
+    const [styledComponentName, styleString] = colorize(
+      'App',
+      ROOT_COMPONENT_BLOCK_STYLE,
+    );
+
+    console.log(
+      `${line}${componentType} ${styledComponentName}`,
+      styleString,
+      domElement,
+    );
+  } else if (fiber.type && fiber.type.name) {
+    const componentName = fiber.type.name;
+    const componentType = '▸';
+
+    const [styledComponentName, styleString] = colorize(
+      componentName,
+      COMPONENT_BLOCK_STYLE,
+    );
+
+    if (componentName === 'Routes' || componentName === 'RenderedRoute') {
+      console.log(
+        `${line}${componentType} ${styledComponentName}`,
+        styleString,
+      );
+    } else {
+      const domElement = findHostComponent(fiber);
+
+      if (domElement) {
+        console.log(
+          `${line}${componentType} ${styledComponentName}`,
+          styleString,
+          domElement,
+        );
+      } else {
+        console.log(
+          `${line}${componentType} ${styledComponentName}`,
+          styleString,
+        );
+      }
+    }
+  }
+
+  if (fiber.child) {
+    let { child } = fiber;
+    let siblingCount = 0;
+
+    while (child) {
+      siblingCount++;
+      child = child.sibling;
+    }
+
+    child = fiber.child;
+    let count = 0;
+
+    while (child) {
+      count++;
+
+      const isLastChild = count === siblingCount;
+      const newPrefix = `${prefix}${isLast ? '  ' : '| '}`;
+
+      traverseFiberTree(child, depth + 1, isLastChild, newPrefix);
+      child = child.sibling;
+    }
+  }
+};
+
+const findAppFiber = (fiber) => {
+  let node = fiber;
+
+  while (node) {
+    if (
+      node.type &&
+      (node.type.name === 'App' || node.type.displayName === 'App')
+    ) {
+      return node;
+    }
+
+    node = node.child;
+  }
+
+  return fiber;
+};
+
+const drawComponentTree = () => {
+  const rootElement = findReactRootNode(document.body);
+
+  if (!rootElement) {
+    console.log('🚫 리액트 루트 요소를 찾을 수 없습니다.');
+  } else {
+    const fiberRoot = findReactFiber(rootElement);
+
+    if (fiberRoot) {
+      const appFiber = findAppFiber(fiberRoot);
+      traverseFiberTree(appFiber, 0, true, '', true);
+    } else {
+      console.log('🚫 파이버 루트를 찾을 수 없습니다.');
+    }
+  }
+};
+
+export { traverseFragment, findReactRootContainer, drawComponentTree };


### PR DESCRIPTION

## 테스크 제목
[[T-20] con.showComponentTree() 구현 - 컴포넌트의 계층 구조를 다이어그램 형식으로 시각화](https://www.notion.so/T-20-con-showComponentTree-0a5dc0c9a9e944e6a276e72ab3a308fb?pvs=4)

<br>

## 설명

`con.showComponentTree()`
리액트 모드일때, showComponentTree() 메서드를 입력하면 현재 화면의 전체 컴포넌트 트리를 콘솔에 출력해주는 기능 
트리와 함께 해당 컴포넌트의 최상위 DOM 엘리먼트를 매칭한 결과를 시각화

1. con.showComponentTree() 메서드 정의

2. 파이버 트리 탐색 알고리즘 

<br>

## 주안점

-  **`traverseFiberTree`함수: 파이버 트리 탐색 알고리즘** 
Fiber 트리를 순회하며 각 노드를 콘솔에 출력합니다. 
`depth`는 트리의 깊이를 나타내고, `isLast`는 현재 노드가 마지막 자식인지 여부를 나타냅니다. 
`prefix`는 각 줄의 접두사를 정의하고, 트리 구조를 시각적으로 나타내는데 사용됩니다.
https://github.com/Team-macoss/con.chat/blob/0564ab26ed511c4aa494eb220359d38e1fad2352/src/utils/component.js#L100-L180

- **`findReactRootNode` 함수**
DOM 요소에서 React 루트 요소를 찾습니다. React 요소는 특정 키 (`__reactFiber$` 또는 `__reactInternalInstance$`)를 가지고 있으므로 해당 키를 통해 찾을 수 있습니다.
`element`가 React 요소인지 확인하고, 그렇지 않으면 자식 요소를 재귀적으로 탐색합니다.

- **`findReactFiber` 함수**
이 함수는 주어진 DOM 요소에서 React Fiber 노드를 찾습니다.  React Fiber는 React 컴포넌트의 데이터 구조로 컴포넌트의 상태와 업데이트를 추적합니다.

- **`findAppFiber` 함수**
Fiber 트리에서 `App` 컴포넌트를 찾습니다. `App` 컴포넌트는 일반적으로 리액트 애플리케이션의 루트 컴포넌트를 의미합니다.

- **`drawComponentTree` 함수**
이 함수를 통해 최종적으로 콘솔에 컴포넌트 트리가 출력됩니다.
`document.body`에서 React 루트 요소를 찾고, 해당 요소에서 Fiber 노드를 찾습니다. 
Fiber 노드를 찾으면 `findAppFiber`를 사용하여 `App` 컴포넌트를 찾아 트리를 순회합니다. 

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.