### PR TITLE
[Feat] con.setAttribute() 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -145,6 +145,15 @@ class Con {
             const { xpath, text } = message.content;
 
             this.#applyTextByXPath(xpath, text, message.username);
+          } else if (message.type === 'setAttribute') {
+            const { xpath, attrName, attrValue } = message.content;
+
+            this.#applyAttributeByXPath(
+              xpath,
+              attrName,
+              attrValue,
+              message.username,
+            );
           } else if (message.type === 'enterRoom') {
             const { username } = message;
 
@@ -370,6 +379,22 @@ class Con {
     }
 
     targetElement.insertAdjacentElement(position, element);
+  }
+
+  #applyAttributeByXPath(xpath, attrName, attrValue, username) {
+    const element = getElementByXPath(xpath);
+
+    if (username !== this.#username) {
+      console.log(
+        `💁🏻 ${username}님이 속성을 변경했습니다. \n\n👇 %ccon.setAttribute('${attrName}', '${attrValue}')`,
+        CODE_BLOCK_STYLE,
+      );
+      console.log(element);
+    }
+
+    if (element) {
+      element.setAttribute(attrName, attrValue);
+    }
   }
 
   #checkDomPreconditions() {
@@ -765,6 +790,40 @@ class Con {
     this.#sendMessageAsync(this.#currentRoomKey, { xpath, text }, 'changeText');
 
     console.log('💁🏻 변경된 텍스트가 사용자들의 화면에 적용되었습니다.');
+  }
+
+  setAttribute(attrName, attrValue) {
+    const targetElement = this.#checkDomPreconditions();
+
+    if (!targetElement) return;
+
+    if (
+      typeof attrName !== 'string' ||
+      attrName.trim() === '' ||
+      typeof attrValue !== 'string' ||
+      attrValue.trim() === ''
+    ) {
+      console.log('🚫 유효한 문자열을 입력해주세요.');
+
+      return;
+    }
+
+    const xpath = getXPath(targetElement);
+    const element = getElementByXPath(xpath);
+
+    if (!element) {
+      console.log('🚫 유효하지 않은 요소입니다. 다른 요소를 선택해주세요.');
+
+      return;
+    }
+
+    this.#sendMessageAsync(
+      this.#currentRoomKey,
+      { xpath, attrName, attrValue },
+      'setAttribute',
+    );
+
+    console.log('💁🏻 설정한 속성이 사용자들의 화면에 적용되었습니다.');
   }
 
   insertElement(element, position) {


### PR DESCRIPTION


## 테스크 제목
[[T-23] con.setAttribute() 구현 - 클릭한 요소의 속성 변경](https://www.notion.so/T-23-con-setAttribute-382fcb5d87e5430b86d2ce0d3bc7144a?pvs=4)

<br>

## 설명
`con.setAttribute(attrName, attrValue)`
사용자가 개발자 도구에서 클릭한 요소의 속성을 설정하는 기능 구현

1. `con.setAttribute()` 메서드 정의
2. 서버로부터 받은 변경요청을 통해 실제 DOM 요소의 속성값을 업데이트하기 위한 `#applyAttributeByXPath` 메서드를 구현

<br>

## 주안점

- 빈 문자열 유효성 검증 
https://github.com/Team-macoss/con.chat/blob/6f6cb97410e5f96b9859389492a81d7ad0dfe75a/src/conchat.js#L800-L809
인자의 type뿐 아니라 빈 문자열의 경우에도 오류 메시지를 출력할 수 있도록 했습니다.
비슷한 DOM 조작 메서드에서도 동일하게 적용되면 좋을 것 같습니다.

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.