### PR TITLE
[Feat] con.removeElement()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -400,6 +400,8 @@ class Con {
     const targetElement = getElementByXPath(targetElementXPath);
     const parentElement = getElementByXPath(parentXPath);
 
+    if (!targetElement || !parentElement) return;
+
     if (username !== this.#username) {
       console.log(
         `💁🏻 ${username}님이 요소를 삭제했습니다. \n\n%c삭제된 요소%c 👇\n\n%c${targetElementOuterHTML}%c\n\n%c삭제된 요소의 부모 요소%c 👇`,
@@ -906,16 +908,18 @@ class Con {
 
   removeElement(element) {
     const selectedElement = this.#checkDomPreconditions();
+    const targetElement = element || selectedElement;
 
-    if (!selectedElement) return;
+    if (!targetElement) {
+      console.log(`🚫 삭제할 요소를 선택해주세요.`);
+    }
 
-    if (element && !(element instanceof HTMLElement)) {
+    if (targetElement && !(targetElement instanceof HTMLElement)) {
       console.log(`🚫 전달하신 요소는 유효한 DOM 요소가 아닙니다.`);
 
       return;
     }
 
-    const targetElement = element || selectedElement;
     const targetElementXPath = getXPath(targetElement);
     const parentXPath = getXPath(targetElement.parentElement);
     const targetElementOuterHTML = targetElement.outerHTML;

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -141,6 +141,16 @@ class Con {
               position,
               message.username,
             );
+          } else if (message.type === 'removeElement') {
+            const { targetElementXPath, parentXPath, targetElementOuterHTML } =
+              message.content;
+
+            this.#applyRemoveByXPath(
+              targetElementXPath,
+              parentXPath,
+              targetElementOuterHTML,
+              message.username,
+            );
           } else if (message.type === 'changeText') {
             const { xpath, text } = message.content;
 
@@ -379,6 +389,31 @@ class Con {
     }
 
     targetElement.insertAdjacentElement(position, element);
+  }
+
+  #applyRemoveByXPath(
+    targetElementXPath,
+    parentXPath,
+    targetElementOuterHTML,
+    username,
+  ) {
+    const targetElement = getElementByXPath(targetElementXPath);
+    const parentElement = getElementByXPath(parentXPath);
+
+    if (username !== this.#username) {
+      console.log(
+        `💁🏻 ${username}님이 요소를 삭제했습니다. \n\n%c삭제된 요소%c 👇\n\n%c${targetElementOuterHTML}%c\n\n%c삭제된 요소의 부모 요소%c 👇`,
+        TEXT_BLOCK_STYLE,
+        'padding: 0',
+        CODE_BLOCK_STYLE,
+        'padding: 0',
+        TEXT_BLOCK_STYLE,
+        'padding: 0',
+      );
+      console.log(parentElement);
+    }
+
+    targetElement.remove();
   }
 
   #applyAttributeByXPath(xpath, attrName, attrValue, username) {
@@ -867,6 +902,41 @@ class Con {
     );
 
     console.log('💁🏻 변경된 요소가 사용자들의 화면에 적용되었습니다.');
+  }
+
+  removeElement(element) {
+    const selectedElement = this.#checkDomPreconditions();
+
+    if (!selectedElement) return;
+
+    if (element && !(element instanceof HTMLElement)) {
+      console.log(`🚫 전달하신 요소는 유효한 DOM 요소가 아닙니다.`);
+
+      return;
+    }
+
+    const targetElement = element || selectedElement;
+    const targetElementXPath = getXPath(targetElement);
+    const parentXPath = getXPath(targetElement.parentElement);
+    const targetElementOuterHTML = targetElement.outerHTML;
+
+    if (!getElementByXPath(targetElementXPath)) {
+      console.log('🚫 유효하지 않은 요소입니다. 다른 요소를 선택해주세요.');
+
+      return;
+    }
+
+    this.#sendMessageAsync(
+      this.#currentRoomKey,
+      {
+        targetElementXPath,
+        parentXPath,
+        targetElementOuterHTML,
+      },
+      'removeElement',
+    );
+
+    console.log('💁🏻 선택한 요소가 사용자들의 화면에 삭제되었습니다.');
   }
 
   searchComponents(targetComponentName) {

--- a/src/constant/chat.js
+++ b/src/constant/chat.js
@@ -2,31 +2,31 @@ const PUBLIC_ROOM_KEY = 'public';
 const DEFAULT_USER_NAME = '아무개';
 
 const CODE_BLOCK_STYLE = `
-  padding: 3px;
-  border-radius: 3px;
+  padding: 3px 5px;
+  border-radius: 4px;
   background-color: #ededeb;
   color: #37352f;
 `;
 
 const TEXT_BLOCK_STYLE = `
-  padding: 3px;
-  border-radius: 3px;
+  padding: 3px 5px;
+  border-radius: 4px;
   background-color: #fbfb87;
   color: #37352f;
 `;
 
 const COMPONENT_BLOCK_STYLE = `
+  padding: 3px 5px;
+  border-radius: 4px;
   background-color: #F2CF65;
   color: #000;
-  padding: 3px 5px;
-  border - radius: 4px;
 `;
 
 const ROOT_COMPONENT_BLOCK_STYLE = `
-  background-color: #96D259;
-  color: #000;
   padding: 3px 5px;
   border-radius: 4px;
+  background-color: #96D259;
+  color: #000;
 `;
 
 export {


### PR DESCRIPTION
## 테스크 제목
[[T-22] con.removeElement() 구현 - 선택한 요소 제거](https://www.notion.so/T-22-con-re-6f5b63c8d607403180c8249a87632be0?pvs=4)


<br>

## 설명
`con.removeElement([element])`
사용자가 개발자 도구에서 클릭한 요소 또는 인자로 전달한 요소를 삭제하는 기능
1. `con.removeElement()` 메서드 정의
2. 서버로 부터 받은 요청로부터 실제 DOM 요소의 삭제가 이뤄질수 있도록 `#applyRemoveByXPath` 메서드 구현

<br>

## 주안점

- 수신자의 화면에 삭제된 요소를 명시해주기 위한 정보
https://github.com/Team-macoss/con.chat/blob/e38916d771e037921506b4081990dc584ac4303e/src/conchat.js#L907-L940
삭제될 요소를 직접 전송하면 이미 DOM에서 요소가 삭제된 후에는 어떤 요소가 삭제되었는지 수신자는 확인할 방법이 없으므로 삭제될 요소의 `parentElement`와 삭제될 요소의 `outerHTML`을 함께 전송하였습니다. 수신자는 삭제된 요소의 태그, 속성 정보와 부모 노드의 정보를 대략적으로 확인할 수 있습니다.

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.