### PR TITLE
[Feat] con.shareComponentTree() 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -1170,6 +1170,26 @@ class Con {
   }
 
   shareComponentTree(username) {
+    if (this.#isStarted()) {
+      console.log('🚫 con.chat()을 실행해주세요.');
+
+      return;
+    }
+
+    if (this.#language !== 'react') {
+      console.log(
+        `🚫 현재 선택된 언어는 ‘react’가 아닙니다. con.setLanguage('react')를 실행해주세요.`,
+      );
+
+      return;
+    }
+
+    if (this.#currentRoomKey === 'public') {
+      console.log('🚫 debug방이 아닌 곳에서 실행할 수 없습니다.');
+
+      return;
+    }
+
     if (typeof username !== 'string' || username.trim() === '') {
       console.log('🚫 유효한 이름을 입력해주세요.');
     }
@@ -1179,7 +1199,7 @@ class Con {
         if (!userExists) {
           console.log(`🚫 ${username}님이 현재 방에 존재하지 않습니다.`);
 
-          return;
+          return Promise.reject(new Error('User not in room'));
         }
 
         const messageRef = this.#getRef(
@@ -1187,7 +1207,7 @@ class Con {
         );
         const newMessageKey = push(messageRef).key;
 
-        set(
+        return set(
           ref(
             this.#database,
             `chats/messages/${this.#currentRoomKey}/${newMessageKey}`,
@@ -1211,7 +1231,9 @@ class Con {
           });
       })
       .catch((error) => {
-        console.error('Error checking if user is in the room:', error);
+        if (error.message !== 'User not in room') {
+          console.error('Error checking if user is in the room:', error);
+        }
       });
   }
 }


### PR DESCRIPTION
## 테스크 제목
[[T-19] con.shareComponentTree() 구현 - 두 사용자의 state와 props 차이점 시각화
](https://www.notion.so/T-19-con-shareComponentTree-state-props-fefd1361055b440aaf4a38779016f98a?pvs=4)
<br>

## 설명
`con.shareComponentTree()`
리액트 모드일 때, shareComponentTree() 메서드를 실행 시 상대방 컴포넌트 트리의 상태와 속성을 비교하고 차이점을 출력하는 기능 구현
트리와 함께 차이점이 있는 경우 해당 컴포넌트에만 차이점 표시

- 순환 참조를 방지하고 불필요한 속성을 제거하기 위한 cleanState 및 cleanProps 함수 작성
- Fiber 트리를 추출하고 정리하는 extractFiberData 함수 구현
- 현재 컴포넌트 트리를 추출하는 logFiberTree 함수 추가
- 두 객체를 비교하여 차이점을 반환하는 compareObjects 함수 작성
- 두 Fiber 노드를 비교하여 상태와 속성의 차이점을 반환하는 compareNodes 함수 구현
- 두 Fiber 트리를 비교하여 전체 차이점을 반환하는 compareTrees 함수 추가
- JSON 문자열화 과정에서 순환 참조를 제거하기 위한 getCircularReplacer 함수 작성
- 정리된 Fiber 트리를 콘솔에 출력하는 printComponentTree 함수 구현
- 메시지 수신 시 컴포넌트 트리를 저장하고 비교하는 기능 추가
- 서버로부터 받은 컴포넌트 트리를 디코딩하고 현재 트리와 비교하여 차이점 출력

<br>

## 주안점

`순환 참조 문제`: Fiber 트리에서 순환 참조가 발생하여 JSON 문자열화가 어려웠습니다.
`불필요한 속성`: 상태와 속성에 포함된 여러 불필요한 내부 속성들이 비교 결과에 포함되었습니다.
`비교 로직`: 두 객체를 비교하는 로직이 복잡하고 정확하지 않았습니다.
`출력 형식`: 차이점을 출력하는 형식이 가독성이 떨어졌습니다.

- **cleanState**, **cleanProps** 함수
  https://github.com/Team-macoss/con.chat/blob/ed62087db11e8fe6a9897fac348370355d957d85/src/utils/component.js#L45-L108
  JSON으로 변환 과정에서 순환 참조가 발생하여 JSON.stringify()가 실패하는 문제가 발생했습니다. 이를 해결하기 위해 순환 참조를 제거하는 로직을 추가하였습니다. cFiber 노드의 상태에는 baseState, baseQueue, deps, destroy, create, _owner, _store, _source 등의 내부 속성이 포함되어 있습니다. 이러한 속성들은 컴포넌트의 렌더링 및 업데이트 과정에서 사용되는 내부 구현 세부사항으로, 실제 상태 비교에서는 불필요합니다. 따라서 이러한 속성을 제거하였습니다. props도 마찬가지로 key, type, ref, _owner, _store, _source 등의 내부 속성이 포함되어 있습니다. 이러한 속성들은 React의 내부 동작에 사용되는 값들로, 실제 props 비교에서는 불필요합니다. 따라서 이러한 속성을 제거하여 비교의 정확성을 높였습니다.

- **extractFiberData** 함수
  https://github.com/Team-macoss/con.chat/blob/ed62087db11e8fe6a9897fac348370355d957d85/src/utils/component.js#L110-L143
  Fiber 트리를 순회하여 각 노드의 상태와 속성을 정리하고 구조화된 데이터로 반환하는 기능을 합니다. Fiber 객체에서 현재 사용목적에 맞지 않는 deps, destory등 불필요한 속성들이 포함되어 있었습니다. 이를 제거하는 과정에서 순환 참조가 발생하여 문제가 되었습니다. 이를 해결하기 위해 cleanState와 cleanProps 함수를 사용하여 불필요한 속성을 제거하고 순환 참조를 방지하였습니다.

- **getCircularReplacer** 함수
  https://github.com/Team-macoss/con.chat/blob/ed62087db11e8fe6a9897fac348370355d957d85/src/utils/component.js#L257-L271
  함수는 WeakSet을 사용하여 이미 처리된 객체를 추적하고, 순환 참조가 발생할 경우 undefined를 반환하여 JSON.stringify()를 사용할 때 순환 참조를 제거할 수 있습니다.

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.