### PR TITLE
[Fix] con.searchComponents() 버그 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.17.1",
+  "version": "0.17.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.17.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -22,7 +22,7 @@ import {
 } from './constant/chat.js';
 import { getXPath, getElementByXPath } from './utils/element.js';
 import {
-  findReactRootContainer,
+  getFiberRoot,
   traverseFragment,
   drawComponentTree,
   logFiberTree,
@@ -42,7 +42,6 @@ class Con {
   #initialDomTree = null;
   #messageListener = null;
   #currentRoomKey = PUBLIC_ROOM_KEY;
-  #rootComponent = null;
   #lastMessageTimestamp = 0;
   #lastMessageKey = '';
   #lastSavedTree = null; // lastSavedTree를 클래스 속성으로 추가
@@ -421,10 +420,6 @@ class Con {
     this.#initialDomTree = domTree;
   }
 
-  set rootComponent(component) {
-    this.#rootComponent = component;
-  }
-
   async #saveComponentTree(targetUser) {
     const tree = logFiberTree();
 
@@ -566,7 +561,7 @@ class Con {
     }
 
     if (this.#currentRoomKey === PUBLIC_ROOM_KEY) {
-      console.log('🚫 방을 개설하여 실행해주세요.');
+      console.log('🚫 해당 메서드는 디버깅 방에서 사용 가능합니다.');
 
       return null;
     }
@@ -818,7 +813,7 @@ class Con {
     }
 
     if (this.#currentRoomKey === PUBLIC_ROOM_KEY) {
-      console.log('🚫 현재 전체 채널을 이용 중입니다.');
+      console.log('🚫 해당 메서드는 디버깅 방에서 사용 가능합니다.');
 
       return;
     }
@@ -1083,20 +1078,23 @@ class Con {
     }
 
     if (this.#currentRoomKey === PUBLIC_ROOM_KEY) {
-      console.log('🚫 debug방이 아닌 곳에서 실행할 수 없습니다.');
+      console.log('🚫 해당 메서드는 디버깅 방에서 사용 가능합니다.');
 
       return;
     }
 
-    if (typeof targetComponentName !== 'string') {
-      console.log('🚫 문자열만 사용가능 합니다. 다시 확인해주세요.');
+    if (
+      typeof targetComponentName !== 'string' ||
+      targetComponentName.trim() === ''
+    ) {
+      console.log('🚫 유효한 문자열을 입력해주세요.');
 
       return;
     }
 
     const foundComponents = [];
 
-    function traverseTree(node) {
+    const traverseTree = (node) => {
       if (!node) return;
 
       if (
@@ -1118,9 +1116,10 @@ class Con {
       if (node.sibling) {
         traverseTree(node.sibling);
       }
-    }
+    };
 
-    traverseTree(this.#rootComponent);
+    const fiberRoot = getFiberRoot();
+    traverseTree(fiberRoot);
 
     if (foundComponents.length === 0) {
       console.log(
@@ -1129,6 +1128,8 @@ class Con {
 
       return;
     }
+
+    console.log(`💁🏻 ${targetComponentName} 컴포넌트의 DOM 요소 👇`);
 
     foundComponents.forEach((component) => {
       if (Array.isArray(component)) {
@@ -1242,5 +1243,4 @@ window.con = new Con();
 
 window.addEventListener('DOMContentLoaded', () => {
   window.con.initialDomTree = document.body.innerHTML;
-  window.con.rootComponent = findReactRootContainer();
 });

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -1241,6 +1241,6 @@ class Con {
 
 window.con = new Con();
 
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('load', () => {
   window.con.initialDomTree = document.body.innerHTML;
 });

--- a/src/utils/component.js
+++ b/src/utils/component.js
@@ -3,7 +3,7 @@ import {
   ROOT_COMPONENT_BLOCK_STYLE,
 } from '../constant/chat.js';
 
-const findReactRootContainer = () => {
+const getFiberRoot = () => {
   const bodyElements = document.body.children;
 
   for (let i = 0; i < bodyElements.length; i++) {
@@ -159,7 +159,7 @@ const extractFiberData = (node, seen = new Map()) => {
 };
 
 const logFiberTree = () => {
-  const fiberRoot = findReactRootContainer();
+  const fiberRoot = getFiberRoot();
 
   if (!fiberRoot) return null;
 
@@ -585,7 +585,7 @@ const drawComponentTree = () => {
 };
 
 export {
-  findReactRootContainer,
+  getFiberRoot,
   traverseFragment,
   drawComponentTree,
   logFiberTree,


### PR DESCRIPTION

## 테스크 제목
[[T-24] con.searchComponent() 버그 수정](https://www.notion.so/T-24-con-searchComponent-42f72dbdd79449898722f4e04ee8dcff?pvs=4)

<br>

## 설명
**fiberRoot 비동기 할당 문제 해결** 

**수정 사항**

- rootComponent set함수 제거
https://github.com/Team-macoss/con.chat/blob/f790e0b72517e85346f3584edb5bb4d32ab349f4/src/conchat.js#L424-L426

- DOM이 로드된 후 rootComponent(fiberRoot) 할당 
https://github.com/Team-macoss/con.chat/blob/f790e0b72517e85346f3584edb5bb4d32ab349f4/src/conchat.js#L1243-L1246
기존에는 DOMContentLoaded 이벤트 실행 후 fiberRoot()를 할당하고 있어, searchComponents 메서드 내부에서 fiberRoot를 정상적으로 참조하지 못하는 문제가 발생했습니다. <br>
`traverseTree(this.#rootComponent);`  <br>
이를 해결하기 위해 `DOMContentLoaded` 이벤트 리스너에 fiberRoot를 할당하는 부분을 제거하고 `searchComponents` 메서드 내부에서 직접 할당하는 방식으로 수정했습니다.
모듈 스크립트는 기본적으로 비동기로 로드되며, `defer` 속성처럼 DOM이 완전히 파싱된 후에 실행됩니다. 따라서 script type="module"을 사용하는 경우, 스크립트가 실행될 때 DOM이 이미 준비되어 있을 가능성이 높으며, `DOMContentLoaded` 이벤트를 기다릴 필요가 없습니다.

<br>

## 주안점
- `traverseTree` 함수 화살표 함수로 수정
https://github.com/Team-macoss/con.chat/blob/9f60c0a09979eb9ef1ef022257178994cc1929b7/src/conchat.js#L1097

- `findReactRootContainer` 함수명 수정
https://github.com/Team-macoss/con.chat/blob/9f60c0a09979eb9ef1ef022257178994cc1929b7/src/utils/component.js#L6
<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.