### PR TITLE
[Feat] con.close() 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.17.2",
+      "version": "0.18.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.17.2",
+  "version": "0.18.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 테스크 제목
[[T-21] con.close() 구현 - 채팅 종료
](https://www.notion.so/T-21-con-close-f1bf84472fbd47598f08cd4b583f9fa2?pvs=4)
<br>

## 설명
`con.close()`
활성화된 채팅 연결을 종료하는 기능 구현

- conchat 종료 시 필요한 작업 수행
  - 현재 방에 종료 메시지 전송 로직 추가
  - 종료 메시지 전송, 메시지 리스너 제거, 이전 방에서 사용자 제거, 데이터 베이스 삭제, 방 삭제를 순차적으로 실행하도록 프라미스 체이닝 적용
  - 채팅 종료 후 메시지를 더 이상 수신하지 않도록 상태 초기화 로직 추가

<br>

## 주안점

- **Promise 체이닝을 사용하여 각 작업을 순차적으로 실행**
  https://github.com/Team-macoss/con.chat/blob/6409d858733dc6c621fe8879dbced4e0f8a58b85/src/conchat.js#L1291-L1320
  초기 구현에서는 사용자 데이터베이스 제거와 방에서 사용자 제거 및 방 삭제를 같이 실행하게 하는 등 비동기 작업 간의 의존성이 명확하지 않아 순서가 꼬이는 문제가 있었습니다. 
이러한 문제를 `Promise 체이닝`을 통해 해결하여 작업 간의 의존성을 유지하도록 하였습니다. 

- **데이터베이스에서 사용자 제거**
  https://github.com/Team-macoss/con.chat/blob/6409d858733dc6c621fe8879dbced4e0f8a58b85/src/conchat.js#L427-L436
  `removeUserFromDatabase` 메서드를 호출하여 사용자 데이터를 Firebase 데이터베이스에서 삭제하였습니다.
이 메서드는 사용자의 `userKey`를 확인하고, 이를 기반으로 데이터를 제거하였습니다. 

- **방에서 사용자 제거 및 방 삭제**
  https://github.com/Team-macoss/con.chat/blob/6409d858733dc6c621fe8879dbced4e0f8a58b85/src/conchat.js#L438-L457
  `removeUserFromRoom` 메서드를 사용하여 사용자를 방에서 제거하고, 
방에 남은 사용자가 없으면 방을 삭제하도록 하였습니다.
이 과정에서 방의 `userList`를 업데이트하고, 비어 있는 방을 삭제하기 위해 기존에 사용하는 메서드인 `deleteRoomIfEmpty` 호출하여 데이터의 일관성을 유지하였습니다.


<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.