### PR TITLE
[Feat] con.showGuide() 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "dependencies": {
         "firebase": "^10.12.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/conchat.js
+++ b/src/conchat.js
@@ -18,7 +18,12 @@ import {
   PUBLIC_ROOM_KEY,
   DEFAULT_USER_NAME,
   CODE_BLOCK_STYLE,
+  CODE_BLOCK_BOLD_STYLE,
   TEXT_BLOCK_STYLE,
+  TEXT_BLOCK_BOLD_STYLE,
+  GUIDE_CONTENT,
+  START_GUIDE_CONTENT,
+  DEBUG_GUIDE_CONTENT,
 } from './constant/chat.js';
 import { getXPath, getElementByXPath } from './utils/element.js';
 import {
@@ -621,7 +626,32 @@ class Con {
     this.#currentRoomKey = PUBLIC_ROOM_KEY;
 
     console.log(
-      '🌽conchat을 시작합니다!\n\n우리는 JavaScript와 React 환경에서 채팅이 가능합니다.\n1. JavaScript\n2. React\n어떤 언어를 사용하고 있나요? con.setLanguage("js" 또는 "react")를 입력해주세요!',
+      '%c🌽 con.chat을 시작합니다!%c\n\n우리는 JavaScript와 React 환경에서 채팅이 가능합니다.\n어떤 언어를 사용하고 있나요? con.setLanguage("js" 또는 "react")를 입력해주세요!',
+      TEXT_BLOCK_BOLD_STYLE,
+      '',
+    );
+    console.log(
+      START_GUIDE_CONTENT,
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
     );
 
     this.#clearMessages(this.#currentRoomKey).then(() => {
@@ -739,6 +769,29 @@ class Con {
         console.log(
           `💁🏻 ${roomName}에 입장했습니다.\n${roomName}은 디버깅 전용 방입니다.\n\nPRIVATE KEY: ${this.#currentRoomKey}`,
         );
+        console.log(
+          DEBUG_GUIDE_CONTENT,
+          TEXT_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+        );
       })
       .catch((error) => {
         if (error.message !== 'Room does not exist') {
@@ -813,6 +866,29 @@ class Con {
       .then(() => {
         console.log(
           `💁🏻 ${roomName}방에 입장했습니다. \n${roomName}방은 디버깅 전용 방입니다. \n\n개발자 도구의 요소 탭 또는 React Developer Tools의 Components 탭에서 엘리먼트를 클릭하세요.`,
+        );
+        console.log(
+          DEBUG_GUIDE_CONTENT,
+          TEXT_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
+          CODE_BLOCK_BOLD_STYLE,
+          '',
         );
       })
       .catch((error) => {
@@ -1256,6 +1332,56 @@ class Con {
           console.error('Error checking if user is in the room:', error);
         }
       });
+  }
+
+  showGuide() {
+    if (this.#isStarted()) {
+      console.log('🚫 con.chat()을 실행해주세요.');
+
+      return;
+    }
+
+    console.log(
+      GUIDE_CONTENT,
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+      CODE_BLOCK_BOLD_STYLE,
+      '',
+    );
   }
 
   close() {

--- a/src/constant/chat.js
+++ b/src/constant/chat.js
@@ -8,6 +8,14 @@ const CODE_BLOCK_STYLE = `
   color: #37352f;
 `;
 
+const CODE_BLOCK_BOLD_STYLE = `
+  padding: 3px 5px;
+  border-radius: 4px;
+  background-color: #ededeb;
+  color: #37352f;
+  font-weight: bold;
+`;
+
 const TEXT_BLOCK_STYLE = `
   padding: 3px 5px;
   border-radius: 4px;
@@ -29,11 +37,276 @@ const ROOT_COMPONENT_BLOCK_STYLE = `
   color: #000;
 `;
 
+const TEXT_BLOCK_BOLD_STYLE = `
+  font-size: 16px; font-weight: bold;
+`;
+
+const GUIDE_CONTENT = `
+🌽 con.chat 사용 가이드 🌽
+
+--------------------------------------------
+
+1. %ccon.chat()%c
+
+👋 채팅을 시작하고 \`con.setLanguage('js' 또는 'react')\`로 언어를 설정합니다.
+
+--------------------------------------------
+
+2. %ccon.setLanguage('language')%c
+
+🌐 채팅 언어를 설정합니다 ('js' 또는 'react').
+
+--------------------------------------------
+
+3. %ccon.speak('Hello, World!')%c
+
+💬 모든 사용자에게 메시지를 전송합니다.
+
+--------------------------------------------
+
+4. %ccon.configuserName('userName')%c
+
+👤 사용자 이름을 설정합니다.
+
+--------------------------------------------
+
+5. %ccon.createDebugRoom('roomName')%c
+
+🐞 디버깅 방을 생성합니다. 고유한 키가 생성됩니다.
+   생성된 키값은 한 번만 볼 수 있으니, 잘 기억하세요!
+   디버깅 방에서는 사용자들간의 DOM 조작이 가능합니다!
+
+--------------------------------------------
+
+6. %ccon.enterDebugRoom('roomName', 'roomKey')%c
+
+🚪 디버깅 방에 입장합니다.
+   방 이름과 키가 일치해야 합니다. 틀리면 열리지 않아요!
+
+--------------------------------------------
+
+7. %ccon.listRooms()%c
+
+📜 모든 디버깅 방의 목록을 조회합니다.
+
+--------------------------------------------
+
+8. %ccon.leaveRoom()%c
+
+🚶 디버깅 방에서 나갑니다.
+
+--------------------------------------------
+
+9. %ccon.changeStyle('color: red; background-color: yellow;')%c
+
+🎨 개발자 도구에서 클릭한 요소의 스타일을 변경합니다.
+
+--------------------------------------------
+
+10. %ccon.changeText('text')%c
+
+🖌️ 개발자 도구에서 클릭한 요소의 텍스트를 변경합니다.
+
+--------------------------------------------
+
+11. %ccon.setAttribute('attrName', 'attrValue')%c
+
+🔧 개발자 도구에서 클릭한 요소의 속성 값을 설정합니다.
+
+--------------------------------------------
+
+12. %ccon.insertElement(element, 'position')%c
+
+📦 개발자 도구에서 클릭한 요소의 주변으로 element를 지정된 위치에 삽입합니다.
+   element는 Javascript 문법을 사용하여 접근할 수 있습니다.
+   position : beforebegin | afterbegin | beforeend | afterend
+
+--------------------------------------------
+
+13. %ccon.removeElement(element)%c
+
+🗑️ element 또는 개발자 도구에서 클릭한 요소를 삭제합니다.
+
+--------------------------------------------
+
+14. %ccon.clearChanges()%c
+
+🧹 모든 DOM 변경 사항을 초기화합니다.
+
+--------------------------------------------
+
+15. %ccon.searchComponents('componentName')%c
+
+🔍 컴포넌트를 이름으로 검색하여 DOM 요소를 확인합니다.
+
+--------------------------------------------
+
+16. %ccon.showComponentTree()%c
+
+🌲 리액트 컴포넌트 트리를 보여줍니다.
+
+--------------------------------------------
+
+17. %ccon.shareComponentTree('userName')%c
+
+👥 리액트 컴포넌트 트리를 비교합니다. 발신자와 수신자의 state와 props를 비교합니다.
+
+--------------------------------------------
+
+18. %ccon.showGuide()%c
+
+📖 con.chat 사용 가이드를 보여줍니다.
+
+--------------------------------------------
+
+19. %ccon.close()%c
+
+❌ 현재 채팅 세션을 종료합니다. 또 만나요!
+
+--------------------------------------------
+
+`;
+
+const START_GUIDE_CONTENT = `
+
+1. %ccon.chat()%c
+
+👋 채팅을 시작하고 \`con.setLanguage('js' 또는 'react')\`로 언어를 설정합니다.
+
+--------------------------------------------
+
+2. %ccon.setLanguage('language')%c
+
+🌐 채팅 언어를 설정합니다 ('js' 또는 'react').
+
+--------------------------------------------
+
+3. %ccon.speak('Hello, World!')%c
+
+💬 모든 사용자에게 메시지를 전송합니다.
+
+--------------------------------------------
+
+4. %ccon.configuserName('userName')%c
+
+👤 사용자 이름을 설정합니다.
+
+--------------------------------------------
+
+5. %ccon.createDebugRoom('roomName')%c
+
+🐞 디버깅 방을 생성합니다. 고유한 키가 생성됩니다.
+   생성된 키값은 한 번만 볼 수 있으니, 잘 기억하세요!
+   디버깅 방에서는 사용자들간의 DOM 조작이 가능합니다!
+
+--------------------------------------------
+
+6. %ccon.enterDebugRoom('roomName', 'roomKey')%c
+
+🚪 디버깅 방에 입장합니다.
+   방 이름과 키가 일치해야 합니다. 틀리면 열리지 않아요!
+
+--------------------------------------------
+
+7. %ccon.listRooms()%c
+
+📜 모든 디버깅 방의 목록을 조회합니다.
+
+--------------------------------------------
+
+8. %ccon.leaveRoom()%c
+
+🚶 디버깅 방에서 나갑니다.
+
+--------------------------------------------
+
+9. %ccon.showGuide()%c
+
+📖 con.chat 사용 가이드를 보여줍니다.
+
+--------------------------------------------
+
+10. %ccon.close()%c
+
+❌ 현재 채팅 세션을 종료합니다. 또 만나요!
+
+--------------------------------------------
+
+`;
+
+const DEBUG_GUIDE_CONTENT = `
+%c🐞 디버깅 메서드 입니다. 🥊%c
+
+--------------------------------------------
+
+1. %ccon.changeStyle('color: red; background-color: yellow;')%c
+
+🎨 개발자 도구에서 클릭한 요소의 스타일을 변경합니다.
+
+--------------------------------------------
+
+2. %ccon.changeText('text')%c
+
+🖌️ 개발자 도구에서 클릭한 요소의 텍스트를 변경합니다.
+
+--------------------------------------------
+
+3. %ccon.setAttribute('attrName', 'attrValue')%c
+
+🔧 개발자 도구에서 클릭한 요소의 속성 값을 설정합니다.
+
+--------------------------------------------
+
+4. %ccon.insertElement(element, 'position')%c
+
+📦 개발자 도구에서 클릭한 요소의 주변으로 element를 지정된 위치에 삽입합니다.
+   element는 Javascript 문법을 사용하여 접근할 수 있습니다.
+   position : beforebegin | afterbegin | beforeend | afterend
+
+--------------------------------------------
+
+5. %ccon.removeElement(element)%c
+
+🗑️ element 또는 개발자 도구에서 클릭한 요소를 삭제합니다.
+
+--------------------------------------------
+
+6. %ccon.clearChanges()%c
+
+🧹 모든 DOM 변경 사항을 초기화합니다.
+
+--------------------------------------------
+
+7. %ccon.searchComponents('componentName')%c
+
+🔍 컴포넌트를 이름으로 검색하여 DOM 요소를 확인합니다.
+
+--------------------------------------------
+
+8. %ccon.showComponentTree()%c
+
+🌲 리액트 컴포넌트 트리를 보여줍니다.
+
+--------------------------------------------
+
+9. %ccon.shareComponentTree('userName')%c
+
+👥 리액트 컴포넌트 트리를 비교합니다. 발신자와 수신자의 state와 props를 비교합니다.
+
+--------------------------------------------
+
+`;
+
 export {
   PUBLIC_ROOM_KEY,
   DEFAULT_USER_NAME,
   CODE_BLOCK_STYLE,
+  CODE_BLOCK_BOLD_STYLE,
   TEXT_BLOCK_STYLE,
   COMPONENT_BLOCK_STYLE,
   ROOT_COMPONENT_BLOCK_STYLE,
+  TEXT_BLOCK_BOLD_STYLE,
+  GUIDE_CONTENT,
+  START_GUIDE_CONTENT,
+  DEBUG_GUIDE_CONTENT,
 };


### PR DESCRIPTION
## 테스크 제목
[[T-25] con.showGuide() 구현 - con.chat 사용 설명서 출력
](https://www.notion.so/T-25-con-showGuide-con-chat-a6918b962921499f991c0da25b3ab519?pvs=4)
<br>

## 설명
`con.showGuide()`
con.chat의 사용 설명서 출력 기능 구현

- con.chat 사용 설명 내용 출력
- con.chat(), con.createDebugRoom(), con.enterDebugRoom() 메서드 실행 시 메서드 설명 추가
- 사용 설명 내용 상수화


<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.